### PR TITLE
Add kqueue(2) for NetBSD and NetBSD Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ lightweight, and it does not require the use of threads (and so does not require
 thread library).
 
 The existing backends include **epoll** and **kqueue**, meaning that Dasynq works well on Linux
-and various BSDs (at least OpenBSD and FreeBSD) as well as Mac OS X ("macOS" as it is now called).
+and various BSDs (at least OpenBSD, FreeBSD and NetBSD) as well as Mac OS X ("macOS" as it is now called).
 There is also a less efficient backend based on **pselect**, and an even less efficient backend
 based on **select**, meaning that it should also work on nearly all other POSIX-compliant systems
 (with minor caveats).
@@ -78,7 +78,7 @@ etc).
 On OpenBSD, you must install "eg++" or llvm; the g++ from the base system is too old (4.2 in OpenBSD 6.1;
 4.9+ is required). The existing makefile sample (Makefile.openbsd) has appropriate settings.
 
-Linux, OpenBSD, FreeBSD and MacOS are supported "out of the box". For other systems you may need to edit
+Linux, OpenBSD, FreeBSD, NetBSD and MacOS are supported "out of the box". For other systems you may need to edit
 the `dasynq-config.h` file (see instructions within). For full functionality either epoll or kqueue are
 required; in many BSD variants it may be possible to build by defining `DASYNQ_HAVE_KQUEUE` to `1`. If
 epoll and kqueue are not available, Dasynq will fall back to using a `pselect`-based backend (or a plain

--- a/include/dasynq/config.h
+++ b/include/dasynq/config.h
@@ -53,7 +53,7 @@
 // ---------------------------------------------------------------------------------------------------------
 
 #if !defined(DASYNQ_HAVE_KQUEUE)
-#if defined(__OpenBSD__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__OpenBSD__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #define DASYNQ_HAVE_KQUEUE 1
 #endif
 #endif

--- a/makefiles/Makefile.netbsd
+++ b/makefiles/Makefile.netbsd
@@ -1,0 +1,11 @@
+# For NetBSD:
+
+CXX = g++
+CXXOPTS = 
+SANITIZE =
+CXXTESTOPTS = -g -std=c++11 -Os -Wall $(SANITIZE)
+CXXLINKOPTS =
+CXXTESTLINKOPTS = -g $(SANITIZE)
+THREADOPT = -pthread
+
+-include Makefile.common


### PR DESCRIPTION
Enable NetBSD kqueue support which is available since NetBSD 2.0.  
Add Makefile for NetBSD, which (still) uses GCC/g++.